### PR TITLE
Update readme to add middleware to web group

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,18 @@ You can install the package via composer:
 $ composer require jacobbennett/laravel-http2serverpush
 ```
 
-Next you must add the `\JacobBennett\Http2ServerPush\Middleware\AddHttp2ServerPush`-middleware to the kernel.
+Next you must add the `\JacobBennett\Http2ServerPush\Middleware\AddHttp2ServerPush`-middleware to the kernel. Adding it to the web group is recommeneded as API's do not have assets to push.
 ```php
 // app/Http/Kernel.php
 
 ...
-protected $middleware = [
+protected $middlewareGroups = [
+    'web' => [
+        ...
+        \JacobBennett\Http2ServerPush\Middleware\AddHttp2ServerPush::class,
+        ...
+    ],
     ...
-    \JacobBennett\Http2ServerPush\Middleware\AddHttp2ServerPush::class,
 ];
 ```
 


### PR DESCRIPTION
Middleware should be in the web group and not global as assets do not normally get pushed from API's and most REST clients do not support HTTP2 Push in the first place.