### PR TITLE
Limit to Links

### DIFF
--- a/src/Middleware/AddHttp2ServerPush.php
+++ b/src/Middleware/AddHttp2ServerPush.php
@@ -25,7 +25,7 @@ class AddHttp2ServerPush
      *
      * @return mixed
      */
-    public function handle(Request $request, Closure $next, int $limit = null)
+    public function handle(Request $request, Closure $next, $limit = null)
     {
         $response = $next($request);
 

--- a/src/Middleware/AddHttp2ServerPush.php
+++ b/src/Middleware/AddHttp2ServerPush.php
@@ -49,14 +49,13 @@ class AddHttp2ServerPush
             ->flatten(1)
             ->map(function ($url) {
                 return $this->buildLinkHeaderString($url);
-            })->filter();
+            })
+            ->filter()
+            ->take($limit)
+            ->implode(',');
 
-        if($limit) $headers = $headers->take($limit);
-
-        $directives = $headers->implode(',');
-
-        if (!empty(trim($directives))) {
-            $this->addLinkHeader($response, $directives);
+        if (!empty(trim($headers))) {
+            $this->addLinkHeader($response, $headers);
         }
 
         return $this;

--- a/src/Middleware/AddHttp2ServerPush.php
+++ b/src/Middleware/AddHttp2ServerPush.php
@@ -43,7 +43,7 @@ class AddHttp2ServerPush
      *
      * @return $this
      */
-    protected function generateAndAttachLinkHeaders(Response $response, int $limit = null)
+    protected function generateAndAttachLinkHeaders(Response $response, $limit = null)
     {
         $headers = $this->fetchLinkableNodes($response)
             ->flatten(1)

--- a/tests/AddHttp2ServerPushTest.php
+++ b/tests/AddHttp2ServerPushTest.php
@@ -99,13 +99,12 @@ class AddHttp2ServerPushTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $limit = 2;
 
-        $response = $this->middleware->handle($request, $this->getNext('pageWithJsInline'), $limit);
+        $response = $this->middleware->handle($request, $this->getNext('pageWithImages'), $limit);
 
         $count = preg_match_all('/(?:\<.*?\>\;\srel\=preload\;\sas\=[a-zA-Z]+\,?)/', $response->headers->get('link'));
 
         $this->assertEquals($limit, $count);
     }
-
 
     /**
      * @param string $pageName

--- a/tests/AddHttp2ServerPushTest.php
+++ b/tests/AddHttp2ServerPushTest.php
@@ -94,7 +94,7 @@ class AddHttp2ServerPushTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
-    public function it_will_return_limit__count_of_links()
+    public function it_will_return_limit_count_of_links()
     {
         $request = new Request();
         $limit = 2;

--- a/tests/AddHttp2ServerPushTest.php
+++ b/tests/AddHttp2ServerPushTest.php
@@ -101,9 +101,7 @@ class AddHttp2ServerPushTest extends \PHPUnit_Framework_TestCase
 
         $response = $this->middleware->handle($request, $this->getNext('pageWithImages'), $limit);
 
-        $count = preg_match_all('/(?:\<.*?\>\;\srel\=preload\;\sas\=[a-zA-Z]+\,?)/', $response->headers->get('link'));
-
-        $this->assertEquals($limit, $count);
+        $this->assertCount($limit, explode(",", $response->headers->get('link')));
     }
 
     /**

--- a/tests/AddHttp2ServerPushTest.php
+++ b/tests/AddHttp2ServerPushTest.php
@@ -93,6 +93,20 @@ class AddHttp2ServerPushTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->isServerPushResponse($response));
     }
 
+    /** @test */
+    public function it_will_return_limit__count_of_links()
+    {
+        $request = new Request();
+        $limit = 20;
+
+        $response = $this->middleware->handle($request, $this->getNext('pageWithJsInline'), $limit);
+
+        $count = preg_match_all('/(?:\<.*?\>\;\srel\=preload\;\sas\=[a-zA-Z]+\,?)/', $response->headers->get('link'));
+
+        $this->assertEquals($limit, $count);
+    }
+
+
     /**
      * @param string $pageName
      *

--- a/tests/AddHttp2ServerPushTest.php
+++ b/tests/AddHttp2ServerPushTest.php
@@ -97,7 +97,7 @@ class AddHttp2ServerPushTest extends \PHPUnit_Framework_TestCase
     public function it_will_return_limit__count_of_links()
     {
         $request = new Request();
-        $limit = 20;
+        $limit = 2;
 
         $response = $this->middleware->handle($request, $this->getNext('pageWithJsInline'), $limit);
 


### PR DESCRIPTION
Hi 
I added optional parameters to middleware.

Example usage:

```php
/**
     * The application's route middleware.
     *
     * These middleware may be assigned to groups or used individually.
     *
     * @var array
     */
    protected $routeMiddleware = [
        ....
        'serverPush' => \JacobBennett\Http2ServerPush\Middleware\AddHttp2ServerPush::class,
        ....
    ];
```

Route:

```php
Route::get('/', 'HomeController@index')->name('home')->middleware('serverPush:50');
```