### PR TITLE
Add SVG push support and excluding favicons

### DIFF
--- a/src/Middleware/AddHttp2ServerPush.php
+++ b/src/Middleware/AddHttp2ServerPush.php
@@ -87,7 +87,7 @@ class AddHttp2ServerPush
     {
         $crawler = $this->getCrawler($response);
 
-        return collect($crawler->filter('link, script[src], img[src], object[data]')->extract(['src', 'href', 'data']));
+        return collect($crawler->filter('link:not([rel*="icon"]), script[src], img[src], object[data]')->extract(['src', 'href', 'data']));
     }
 
     /**

--- a/src/Middleware/AddHttp2ServerPush.php
+++ b/src/Middleware/AddHttp2ServerPush.php
@@ -107,6 +107,7 @@ class AddHttp2ServerPush
             '.JPG'  => 'image',
             '.JPEG' => 'image',
             '.PNG'  => 'image',
+            '.SVG'  => 'image',
             '.TIFF' => 'image',
         ];
 

--- a/src/Middleware/AddHttp2ServerPush.php
+++ b/src/Middleware/AddHttp2ServerPush.php
@@ -87,7 +87,7 @@ class AddHttp2ServerPush
     {
         $crawler = $this->getCrawler($response);
 
-        return collect($crawler->filter('link, script[src], img[src]')->extract(['src', 'href']));
+        return collect($crawler->filter('link, script[src], img[src], object[data]')->extract(['src', 'href', 'data']));
     }
 
     /**

--- a/tests/AddHttp2ServerPushTest.php
+++ b/tests/AddHttp2ServerPushTest.php
@@ -2,8 +2,6 @@
 
 namespace JacobBennett\Http2ServerPush\Test;
 
-// TODO: test for invalid file types like .svg
-
 use Illuminate\Http\Request;
 use JacobBennett\Http2ServerPush\Middleware\AddHttp2ServerPush;
 use Symfony\Component\HttpFoundation\Response;
@@ -57,7 +55,19 @@ class AddHttp2ServerPushTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($this->isServerPushResponse($response));
         $this->assertStringEndsWith("as=image", $response->headers->get('link'));
-        $this->assertCount(6, explode(",", $response->headers->get('link')));
+        $this->assertCount(7, explode(",", $response->headers->get('link')));
+    }
+
+    /** @test */
+    public function it_will_return_an_image_link_header_for_svg_objects()
+    {
+        $request = new Request();
+
+        $response = $this->middleware->handle($request, $this->getNext('pageWithSVGObject'));
+
+        $this->assertTrue($this->isServerPushResponse($response));
+        $this->assertStringEndsWith("as=image", $response->headers->get('link'));
+        $this->assertCount(1, explode(",", $response->headers->get('link')));
     }
 
     /** @test */

--- a/tests/AddHttp2ServerPushTest.php
+++ b/tests/AddHttp2ServerPushTest.php
@@ -104,6 +104,16 @@ class AddHttp2ServerPushTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_will_not_return_a_push_header_for_icons()
+    {
+        $request = new Request();
+
+        $response = $this->middleware->handle($request, $this->getNext('pageWithFavicon'));
+
+        $this->assertFalse($this->isServerPushResponse($response));
+    }
+
+    /** @test */
     public function it_will_return_limit_count_of_links()
     {
         $request = new Request();

--- a/tests/fixtures/pageWithFavicon.html
+++ b/tests/fixtures/pageWithFavicon.html
@@ -1,0 +1,12 @@
+<html>
+
+    <head>
+        <title>Page title</title>
+        <link rel="apple-touch-icon-precomposed" href="/favicon-apple.png"/>
+        <link rel="icon" href="favicon.png">
+    </head>
+
+    <body>
+    </body>
+
+</html>

--- a/tests/fixtures/pageWithImages.html
+++ b/tests/fixtures/pageWithImages.html
@@ -11,6 +11,7 @@
         <img src="/images/photo.jpeg" alt="">
         <img src="/images/logo.png" alt="">
         <img src="/images/noidea.tiff" alt="">
+        <img src="/images/vector.svg" alt="">
     </body>
 
 </html>

--- a/tests/fixtures/pageWithSVGObject.html
+++ b/tests/fixtures/pageWithSVGObject.html
@@ -1,0 +1,11 @@
+<html>
+
+    <head>
+        <title>Page title</title>
+    </head>
+
+    <body>
+        <object data="/images/vector.svg" alt="">
+    </body>
+
+</html>

--- a/tests/fixtures/pageWithSVGObject.html
+++ b/tests/fixtures/pageWithSVGObject.html
@@ -5,7 +5,7 @@
     </head>
 
     <body>
-        <object data="/images/vector.svg" alt="">
+        <object data="/images/vector.svg" type="image/svg+xml"></object>
     </body>
 
 </html>


### PR DESCRIPTION
SVG is a common image type used on the web and would also benefit from being pushed from the server.