### PR TITLE
Remove PHP 5 Composer Version Constraint 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php" : "^5.5|^7.0",
+        "php" : "^7.0",
         "illuminate/support": "^5.3",
         "illuminate/http": "^5.3",
         "symfony/dom-crawler": "^2.7|^3.0|^4.0",


### PR DESCRIPTION
We're using the null coalescing operator [here](https://github.com/JacobBennett/laravel-HTTP2ServerPush/blob/master/src/Middleware/AddHttp2ServerPush.php#L54) which was introduced in PHP 7