### PR TITLE
Use "as=fetch" in case no extension is matched

### DIFF
--- a/src/Middleware/AddHttp2ServerPush.php
+++ b/src/Middleware/AddHttp2ServerPush.php
@@ -140,6 +140,9 @@ class AddHttp2ServerPush
             return Str::contains(strtoupper($url), $extension);
         });
 
+        if ($url && !$type) {
+            $type = 'fetch';
+        }
 
         if(!preg_match('%^(https?:)?//%i', $url)) {
             $basePath = $this->getConfig('base_path', '/');

--- a/tests/AddHttp2ServerPushTest.php
+++ b/tests/AddHttp2ServerPushTest.php
@@ -99,6 +99,18 @@ class AddHttp2ServerPushTest extends TestCase
     }
 
     /** @test */
+    public function it_will_return_a_fetch_link_header_for_fetch()
+    {
+        $request = new Request();
+
+        $response = $this->middleware->handle($request, $this->getNext('pageWithFetchPreload'));
+
+        $this->assertTrue($this->isServerPushResponse($response));
+        $this->assertStringContainsString('</api/resource>; rel=preload', $response->headers->get('link'));
+        $this->assertStringEndsWith("as=script", $response->headers->get('link'));
+    }
+
+    /** @test */
     public function it_returns_well_formatted_link_headers()
     {
         $request = new Request();

--- a/tests/fixtures/pageWithFetchPreload.html
+++ b/tests/fixtures/pageWithFetchPreload.html
@@ -1,0 +1,13 @@
+<html>
+
+    <head>
+        <title>Page title</title>
+        <link rel="preload" href="/api/resource" as="fetch">
+    </head>
+
+    <body>
+
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/vue/1.0.26/vue.min.js"></script>
+    </body>
+
+</html>


### PR DESCRIPTION
Links like

` <link rel="preload" href="/api/events" as="fetch">`

Are now supported